### PR TITLE
use setup_py_install

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,15 @@
+build:
+    image: latest
+
 formats:
     - none
 conda:
     file: ci/rtd_env.yml
 python:
   version: 3.7
+  setup_py_install: true
   install:
     - method: pip
       path: .
+    - method: setuptools
+      path: package


### PR DESCRIPTION
Fix use of automodule extension in Sphinx by using `setup_py_install`.